### PR TITLE
fix vertical nodes

### DIFF
--- a/src/orgchart.js
+++ b/src/orgchart.js
@@ -1504,7 +1504,7 @@ export default class OrgChart {
 
       if (isVerticalLayer) {
         nodeLayer = document.createElement('ul');
-        if (isHidden) {
+        if (isHidden && level + 2 !== opts.verticalDepth) {
           nodeLayer.classList.add(isHidden.trim());
         }
         if (level + 2 === opts.verticalDepth) {


### PR DESCRIPTION
The top vertical nodes could not be expaned when `verticalDepth` is greater than `depth`.
Prevent adding `hidden` class for the top vertical `ul` could fix the bug, because the `verticalNodes` classed element already has the `hidden` class.