### PR TITLE
It validates that the “children” property is not an empty array

### DIFF
--- a/src/orgchart.js
+++ b/src/orgchart.js
@@ -1430,8 +1430,8 @@ export default class OrgChart {
     // Construct the node
     let that = this,
       opts = this.options,
-      nodeWrapper,
-      childNodes = nodeData.children,
+      nodeWrapper,      
+      childNodes = (nodeData.children && nodeData.children.length > 0) && nodeData.children,
       isVerticalNode = opts.verticalDepth && (level + 1) >= opts.verticalDepth;
 
     if (Object.keys(nodeData).length > 1) { // if nodeData has nested structure


### PR DESCRIPTION
This change is just to avoid draw lines when the "children" property is an empty array.