### PR TITLE
add option useGhostImage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ logs
 
 # Dependency directory
 node_modules
+package-lock.json
 
 # build files
 build

--- a/src/orgchart.js
+++ b/src/orgchart.js
@@ -1179,11 +1179,15 @@ export default class OrgChart {
         let ghostNodeWrapper = document.createElement('img');
 
         ghostNodeWrapper.src = 'data:image/svg+xml;utf8,' + (new XMLSerializer()).serializeToString(ghostNode);
-        event.dataTransfer.setDragImage(ghostNodeWrapper, xOffset, yOffset);
+        if(opts.useGhostImage){
+          event.dataTransfer.setDragImage(ghostNodeWrapper, xOffset, yOffset);
+        }
         nodeCover.setAttribute('fill', 'rgb(255, 255, 255)');
         nodeCover.setAttribute('stroke', 'rgb(191, 0, 0)');
       } else {
-        event.dataTransfer.setDragImage(ghostNode, xOffset, yOffset);
+        if(opts.useGhostImage){
+          event.dataTransfer.setDragImage(ghostNode, xOffset, yOffset);
+        }
       }
     }
     let dragged = event.target,


### PR DESCRIPTION
Added an option to disable manual override of ghost image because this will cause a very ugly shape in almost 99% of the cases.

This would allow for an easy fix for those issues without breaking compatibility for existing deployments.
https://github.com/dabeng/OrgChart/issues/212

Just pass 'useGhostImage': false

And it will give you a nice drag image if the browser supports it

![image](https://user-images.githubusercontent.com/38694044/65040637-2227ec00-d955-11e9-9618-78bbbbe94901.png)

